### PR TITLE
Global variables for configuring plugin didn't work

### DIFF
--- a/lua/gist/core/gh.lua
+++ b/lua/gist/core/gh.lua
@@ -44,14 +44,14 @@ end
 --
 -- @return table A table with the configuration properties
 function M.read_config()
-	local ok, values = pcall(vim.api.nvim_get_var, { "gist_is_private", "gist_clipboard" })
-
-	local is_private = ok and values[1] or false
-	local clipboard = ok and values[2] or "+"
+	local ok_private, private = pcall(vim.api.nvim_get_var, "gist_is_private")
+	local is_private = ok_private and private or false
+	local ok_clipboard, clipboard = pcall(vim.api.nvim_get_var, "gist_clipboard")
+	local clipboard_reg = ok_clipboard and clipboard or "+"
 
 	local config = {
 		is_private = is_private,
-		clipboard = clipboard,
+		clipboard = clipboard_reg,
 	}
 
 	return config


### PR DESCRIPTION
This PR fixes an issue with `pcall` and `nvim_get_var` that caused the global variables for configuring the plugin to not work properly. The original code used a table with 2 strings in the `pcall` call, but `nvim_get_var` expected only a single string not a table (`:h nvim_get_var`).

If a table is passed as the second argument to `pcall`, its items are not treated as single argument to pass to multiple function calls. (though that would be cool)
```help
pcall({f}, {arg1}, {...})                                       *luaref-pcall()*
        Calls function {f} with the given arguments in `protected mode`.
```

To fix this issue, I modified the code to read the 2 global variables (`gist_is_private` and `gist_clipboard`) in 2 separate calls to `nvim_get_var`.


I have tested this change on my local machine and verified that it works as expected.
