### PR TITLE
Ask to confirm before creating the gist

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Both the commands accept the same options which are `[description=]` and `[publi
 If you don't pass the `description` it will prompt to insert one later.
 If you pass `[public=true]` it won't prompt for privacy later.
 
-After you enter the description and privacy settings, the plugin will create the Gist using the gh command-line tool and copy the Gist's URL to the given clipboard registry.
+After you enter the description and privacy settings, the plugin ask for confirmation and will create the Gist using the gh command-line tool and copy the Gist's URL to the given clipboard registry.
 
 ## Configuration
 

--- a/doc/gist.config.txt
+++ b/doc/gist.config.txt
@@ -1,7 +1,7 @@
 *gist.config.txt*  CreateGist configuration
 
 DESCRIPTION
-    The `:CreateGist` command can be configured to avoid prompting the user for the privacy settings of the Gist and target clipboard. 
+    The `:CreateGist` command can be configured to avoid prompting the user for the privacy settings of the Gist and target clipboard.
     This is done by setting the `gist_clipboard` and `gist_privacy` variables in your `init.vim` file.
 
 OPTIONS

--- a/doc/gist.txt
+++ b/doc/gist.txt
@@ -8,8 +8,8 @@ SYNOPSIS
     :CreateGistFromFile
 
 DESCRIPTION
-    The `:CreateGist` command creates a GitHub Gist from the buffer selection using the `gh` command-line tool. 
-    The `:CreateGistFile` command creates a GitHub Gist from the current file using the `gh` command-line tool. 
+    The `:CreateGist` command creates a GitHub Gist from the buffer selection using the `gh` command-line tool.
+    The `:CreateGistFile` command creates a GitHub Gist from the current file using the `gh` command-line tool.
 
     The plugin prompts you for a description and privacy settings for the Gist, and then copies the URL of the created Gist to the system clipboard.
 
@@ -22,8 +22,8 @@ EXAMPLES
 
         :CreateGistFile [description] [public=true]
 
-    The plugin will prompt you for a description and privacy settings for the Gist. 
-    After you enter the description and privacy settings, the plugin will create the Gist using the `gh` command-line tool and copy the URL of the created Gist to the system clipboard.
+    The plugin will prompt you for a description and privacy settings for the Gist.
+    After you enter the description and privacy settings, the plugin will ask for confirmation and create the Gist using the `gh` command-line tool and copy the URL of the created Gist to the system clipboard.
 
     To Create a Gist from current selection, run the following command in Neovim:
 

--- a/lua/gist/core/gh.lua
+++ b/lua/gist/core/gh.lua
@@ -29,6 +29,13 @@ function M.create_gist(filename, content, description, private)
 		)
 	end
 
+	local ans = vim.fn.input("Do you want to create gist " .. filename .. " (y/n)? ")
+	if ans ~= "y" then
+		vim.cmd.redraw()
+		vim.notify("Gist creation aborted", vim.log.levels.INFO)
+		return
+	end
+
 	local output = utils.exec(cmd, content)
 
 	if vim.v.shell_error ~= 0 then

--- a/lua/gist/init.lua
+++ b/lua/gist/init.lua
@@ -29,6 +29,7 @@ local function create(content, ctx)
 	local details = get_details(ctx)
 
 	local url, err = core.create_gist(details.filename, content, details.description, details.is_private)
+	if not url then return end
 
 	if err ~= nil then
 		vim.api.nvim_err_writeln("Error creating Gist: " .. err)


### PR DESCRIPTION
The plugin by default creates the gist even if the user tries to cancel out because of an error in the descriptio or privacy setting.

Asking to confirm would be smarter, now by default if you spam press enter after `CreateGist` it doesn't create it you actually have to type `y` at the end.

Something we might add:
- Option to disable this setting (useful if someone uses the plugin a lot and gets bored of typing to confirm)
- More informative message when asking confirmation (print the description and privacy maybe)