### PR TITLE
add option to set split direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ You can also list your gists and edit their files on the fly.
         private = false, -- All gists will be private, you won't be prompted again
         clipboard = "+", -- The registry to use for copying the Gist URL
         -- gh_cmd = "gh"
+        split_direction = "vertical", -- default: "vertical" - set window split orientation when opening a gist ("vertical" or "horizontal")
         list = {
             -- If there are multiple files in a gist you can scroll them,
             -- with vim-like bindings n/p next previous

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ return {
     cmd = { "GistCreate", "GistCreateFromFile", "GistsList" },
     config = true
   },
-  -- `GistsList` opens the selected gif in a terminal buffer,
+  -- `GistsList` opens the selected gist in a terminal buffer,
   -- nvim-unception uses neovim remote rpc functionality to open the gist in an actual buffer
   -- and prevents neovim buffer inception
   {
@@ -77,6 +77,7 @@ You can also list your gists and edit their files on the fly.
     require("gist").setup({
         private = false, -- All gists will be private, you won't be prompted again
         clipboard = "+", -- The registry to use for copying the Gist URL
+        -- gh_cmd = "gh"
         list = {
             -- If there are multiple files in a gist you can scroll them,
             -- with vim-like bindings n/p next previous
@@ -87,6 +88,11 @@ You can also list your gists and edit their files on the fly.
         }
     })
 ```
+
+By default `gh_cmd` is set to the default `gh` command. However, there may be
+cases where you want to override this with your custom wrapper.  Users of the
+1password op plugin will likely want to point to the wrapper command.
+(example: `op plugin run -- gh`)
 
 ## License
 

--- a/doc/gist.config.txt
+++ b/doc/gist.config.txt
@@ -10,6 +10,7 @@ DESCRIPTION
 OPTIONS
 	private = false, will set the privacy to `public` by default.
 	clipboard = "0", will set the clipboard to `+` by default, it is the unnamed_plus register `:h quoteplus`.
+	split_direction = "vertical", controls the split orientation when opening a gist. can be "vertical" or "horizontal".
     next_file = "<C-n>",
     prev_file = "<C-p>",
 

--- a/lua/gist/api/list.lua
+++ b/lua/gist/api/list.lua
@@ -4,7 +4,12 @@ local config = require("gist").config
 local M = {}
 
 local function create_split_terminal(command)
-    vim.cmd.vsplit()
+    local config = require("gist").config
+    if config.split_direction == "vertical" then
+      vim.cmd.vsplit()
+    else
+      vim.cmd.split()
+    end
     local win = vim.api.nvim_get_current_win()
     local buf = vim.api.nvim_create_buf(false, true)
     vim.api.nvim_win_set_buf(win, buf)

--- a/lua/gist/core/gh.lua
+++ b/lua/gist/core/gh.lua
@@ -13,12 +13,18 @@ function M.create_gist(filename, content, description, private)
     local public_flag = private and "" or "--public"
     description = vim.fn.shellescape(description)
 
+    local config = require("gist").config
     local cmd
+
+    -- split the gh_cmd into components to handle wrappers properly
+    local cmd_parts = vim.split(config.gh_cmd, " ")
+    local base_cmd = table.concat(cmd_parts, " ")
 
     if content ~= nil then
         filename = vim.fn.shellescape(filename)
         cmd = string.format(
-            "gh gist create -f %s -d %s %s",
+            "%s gist create -f %s -d %s %s",
+            base_cmd,
             filename,
             description,
             public_flag
@@ -26,7 +32,8 @@ function M.create_gist(filename, content, description, private)
     else
         -- expand filepath if no content is provided
         cmd = string.format(
-            "gh gist create %s %s --filename %s -d %s",
+            "%s gist create %s %s --filename %s -d %s",
+            base_cmd,
             vim.fn.expand("%"),
             public_flag,
             filename,
@@ -57,7 +64,10 @@ end
 --
 -- @return [string]|nil The URLs of all the Gists
 function M.list_gists()
-    local cmd = "gh gist list"
+    local config = require("gist").config
+    -- create a command that properly handles command wrappers
+    local cmd_parts = vim.split(config.gh_cmd, " ")
+    local cmd = table.concat(cmd_parts, " ") .. " gist list"
 
     local output = utils.exec(cmd)
     if type(output) == "string" then

--- a/lua/gist/core/utils.lua
+++ b/lua/gist/core/utils.lua
@@ -62,7 +62,9 @@ function M.exec(cmd, stdin)
     -- print(string.format("Executing: %s", cmd))
     local tmp = os.tmpname()
 
-    local pipe = io.popen(cmd .. "> " .. tmp, "w")
+    -- ensure command is properly formatted as a string
+    local cmd_str = type(cmd) == "table" and table.concat(cmd, " ") or cmd
+    local pipe = io.popen(cmd_str .. "> " .. tmp, "w")
 
     if not pipe then
         return nil

--- a/lua/gist/init.lua
+++ b/lua/gist/init.lua
@@ -3,6 +3,7 @@ local M = {}
 M.config = {
     private = false,
     clipboard = "+",
+    gh_cmd = "gh",
     list = {
         mappings = {
             next_file = "<C-n>",

--- a/lua/gist/init.lua
+++ b/lua/gist/init.lua
@@ -4,6 +4,7 @@ M.config = {
     private = false,
     clipboard = "+",
     gh_cmd = "gh",
+    split_direction = "vertical",
     list = {
         mappings = {
             next_file = "<C-n>",


### PR DESCRIPTION
adds a new config option (`split_direction` - defaults to "vertical") which controls the direction of the window split for a gist edit operation.