### PR TITLE
allow gistcreate in unnamed buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,15 @@ To create a gist from the current file, use the `:GistCreateFromFile` command in
 The plugin will prompt you for a description and whether the gist should be private or public (depending on the platform).
 
 ```vim
-  :GistCreate [description] [public=true]
+  :GistCreate [description] [filename=example.lua] [public=true]
 ```
 
 - `:GistCreate` will create the gist from the current selection or the entire buffer if no selection is made
 - `:GistCreateFromFile` will create the gist from the current file
 
-Both commands accept the same options: `[description=]` and `[public=true]`
+Both commands accept the same options: `[description=]`, `[filename=]`, and `[public=true]`
+
+When the current buffer has no filename, `:GistCreate` will use the buffer contents directly and default the filename to `untitled` unless you pass `filename=` explicitly.
 
 If you don't pass the `description` it will prompt to insert one later.
 If you pass `[public=true]` it won't prompt for privacy later.

--- a/lua/gist/api/create.lua
+++ b/lua/gist/api/create.lua
@@ -3,6 +3,20 @@ local utils = require("gist.core.utils")
 
 local M = {}
 
+---@param opts table
+---@param args table
+---@return string?
+local function get_description(opts, args)
+    if args.description ~= nil then
+        return args.description
+    end
+
+    local first_arg = opts.fargs[1]
+    if first_arg ~= nil and not first_arg:find("=", 1, true) then
+        return first_arg
+    end
+end
+
 ---@param content string
 ---@param ctx CreateContext
 local function create(content, ctx)
@@ -46,29 +60,33 @@ end
 --- Creates a Gist from the current selection
 function M.from_buffer(opts)
     local content = nil
-    local args = utils.parseArgs(opts.args)
+    local args = utils.parseArgs(opts.fargs)
 
     local start_line = opts.line1
     local end_line = opts.line2
-    local description = opts.fargs[1]
+    local description = get_description(opts, args)
 
-    if start_line ~= end_line then
+    if opts.range > 0 then
         content = utils.get_current_selection(start_line, end_line)
+    else
+        content = utils.read_current_buffer_content()
     end
 
     return create(content, {
         description = description,
+        filename = args.filename,
         is_public = args.public,
     })
 end
 
 --- Creates a Gist from the current file.
 function M.from_file(opts)
-    local args = utils.parseArgs(opts.args)
-    local description = opts.fargs[1]
+    local args = utils.parseArgs(opts.fargs)
+    local description = get_description(opts, args)
 
     create(nil, {
         description = description,
+        filename = args.filename,
         is_public = args.public,
     })
 end

--- a/lua/gist/core/0x0.lua
+++ b/lua/gist/core/0x0.lua
@@ -52,9 +52,9 @@ function M.create(_, content, _, private)
     return url, nil
 end
 
-function M.get_create_details()
+function M.get_create_details(ctx)
     return {
-        filename = vim.fn.expand("%:t"),
+        filename = utils.resolve_filename(ctx and ctx.filename),
         description = "",
         is_private = gist.config.platforms["0x0"].private or false,
     }

--- a/lua/gist/core/gh.lua
+++ b/lua/gist/core/gh.lua
@@ -39,9 +39,9 @@ function M.create(filename, content, description, private)
         cmd = string.format(
             "%s gist create %s %s --filename %s -d %s",
             base_cmd,
-            vim.fn.expand("%"),
+            vim.fn.shellescape(vim.fn.expand("%")),
             public_flag,
-            filename,
+            vim.fn.shellescape(filename),
             description
         )
     end
@@ -167,7 +167,7 @@ function M.get_create_details(ctx)
     ---@type Gist.Prompts.Create
     local prompts = config.prompts and config.prompts.create or {}
 
-    local filename = vim.fn.expand("%:t")
+    local filename = utils.resolve_filename(ctx.filename)
     local description = ""
     if prompts.description then
         description = ctx.description

--- a/lua/gist/core/gitlab.lua
+++ b/lua/gist/core/gitlab.lua
@@ -61,7 +61,7 @@ function M.get_create_details(ctx)
     ---@type Gist.Prompts.Create
     local prompts = gist.config.prompts and gist.config.prompts.create or {}
 
-    local filename = vim.fn.expand("%:t")
+    local filename = utils.resolve_filename(ctx.filename)
 
     local description = ""
     if prompts.description then

--- a/lua/gist/core/pastecn.lua
+++ b/lua/gist/core/pastecn.lua
@@ -81,7 +81,7 @@ function M.get_create_details(ctx)
     ---@type Gist.Prompts.Create
     local prompts = gist.config.prompts.create
 
-    local filename = vim.fn.expand("%:t")
+    local filename = utils.resolve_filename(ctx.filename)
 
     local description = ""
     if prompts.description then

--- a/lua/gist/core/services.lua
+++ b/lua/gist/core/services.lua
@@ -1,3 +1,4 @@
+local utils = require("gist.core.utils")
 local gh = require("gist.core.gh")
 local termbin = require("gist.core.termbin")
 local gitlab = require("gist.core.gitlab")
@@ -110,19 +111,19 @@ function M.get_create_details(ctx)
     if platform == "github" then
         return gh.get_create_details(ctx)
     elseif platform == "termbin" then
-        return termbin.get_create_details()
+        return termbin.get_create_details(ctx)
     elseif platform == "gitlab" then
         return gitlab.get_create_details(ctx)
     elseif platform == "sourcehut" then
         return sourcehut.get_create_details(ctx)
     elseif platform == "0x0" then
-        return x0.get_create_details()
+        return x0.get_create_details(ctx)
     elseif platform == "pastecn" then
         return pastecn.get_create_details(ctx)
     else
         --- @type Gist.Prompts.Create
         local prompts = gist.config.prompts.create
-        local filename = vim.fn.expand("%:t")
+        local filename = utils.resolve_filename(ctx.filename)
 
         local description = ""
         if prompts.description then

--- a/lua/gist/core/termbin.lua
+++ b/lua/gist/core/termbin.lua
@@ -35,9 +35,9 @@ end
 
 --- Get details for creating a paste (termbin doesn't support most options)
 ---@return CreateDetails
-function M.get_create_details()
+function M.get_create_details(ctx)
     return {
-        filename = vim.fn.expand("%:t"),
+        filename = utils.resolve_filename(ctx and ctx.filename),
         description = "",
         is_private = false,
     }

--- a/lua/gist/core/types.lua
+++ b/lua/gist/core/types.lua
@@ -5,4 +5,5 @@
 
 ---@class CreateContext
 ---@field description string?
+---@field filename string?
 ---@field is_public boolean?

--- a/lua/gist/core/utils.lua
+++ b/lua/gist/core/utils.lua
@@ -87,24 +87,45 @@ function M.extract_gist_url(output)
     return output:match(pattern)
 end
 
--- @param args string
-function M.parseArgs(args)
-    -- parse args as key=value
+--- Parse `key=value` command arguments. Accepts Neovim's `opts.fargs` so
+--- quoted/escaped values are preserved by the command parser. Splits each arg
+--- on the first `=` only, so values may themselves contain `=`.
+---@param fargs string[]
+function M.parseArgs(fargs)
     local parsed = {}
 
-    for _, arg in ipairs(vim.split(args, " ", {})) do
-        local key, value = unpack(vim.split(arg, "=", { plain = true }))
+    for _, arg in ipairs(fargs) do
+        local eq = arg:find("=", 1, true)
+        if eq then
+            local key = arg:sub(1, eq - 1)
+            local value = arg:sub(eq + 1)
 
-        if value == "true" then
-            value = true
-        elseif value == "false" then
-            value = false
+            if value == "true" then
+                value = true
+            elseif value == "false" then
+                value = false
+            end
+
+            parsed[key] = value
         end
-
-        parsed[key] = value
     end
 
     return parsed
+end
+
+---@param filename string?
+---@return string
+function M.resolve_filename(filename)
+    if filename ~= nil and filename ~= "" then
+        return filename
+    end
+
+    filename = vim.fn.expand("%:t")
+    if filename ~= nil and filename ~= "" then
+        return filename
+    end
+
+    return "untitled"
 end
 
 function M.detect_multiplexer()

--- a/plugin/gist.lua
+++ b/plugin/gist.lua
@@ -1,13 +1,13 @@
 local gist = require("gist.api")
 
 local complete = function()
-    return { "description=", "public=" }
+    return { "description=", "filename=", "public=" }
 end
 
 vim.api.nvim_create_user_command("GistCreate", function(args)
     gist.create_from_buffer(args)
 end, {
-    nargs = "?",
+    nargs = "*",
     desc = "Create a Gist from the current buffer selection.",
     range = true,
     complete = complete,
@@ -16,7 +16,7 @@ end, {
 vim.api.nvim_create_user_command("GistCreateFromFile", function(args)
     gist.create_from_file(args)
 end, {
-    nargs = "?",
+    nargs = "*",
     desc = "Create a Gist from the current buffer.",
     range = false,
     complete = complete,


### PR DESCRIPTION
References #28

`:GistCreate` was documented to use the current selection or buffer contents, but when no range was given it fell back to the current file path. That made unnamed buffers fail with an opaque shell error and also skipped live buffer contents unless the file had already been written.

Switch `:GistCreate` to read buffer text unless an explicit range is provided, add `filename=` support with an `untitled` fallback for buffers without a path, and allow multiple `key=value` arguments so `filename`, `public`, and `description` can be passed together. `:GistCreateFromFile` keeps the file-backed behavior, but now shares the same filename override path.

A small `get_description` helper replaces `opts.fargs[1]`, because positional args can now interleave with `key=value` entries. It accepts an explicit `description=...` or the first positional arg that does not contain `=`, so `:GistCreate filename=foo "my desc"` and `:GistCreate "my desc" public=true` both work.

Argument parsing takes `opts.fargs` so neovim handles splitting (preserving quoted/escaped values) and splits each entry only at the first `=` so values may themselves contain `=`. The `gh` file-backed branch now `shellescape`s the expanded path and the user-supplied filename, matching the content branch.